### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ openbmclapi 会自行同步需要的文件, 但是初次同步可能会速度过
 - `rsync -rzvP openbmclapi@home.933.moe::openbmclapi cache`
 - `rsync -avP openbmclapi@storage.yserver.ink::bmcl cache`
 - `rsync -azvrhP openbmclapi@openbmclapi.home.mxd.moe::volume cache`
-- `rsync -avP --delete --exclude="@Recently-Snapshot" --exclude="@Recycle" openbmclapi@lineapp.ltd::BMCLAPI-CACHE /pathtoyourcache/（密码是openbmclapi123）`
+- `rsync -avP --delete --exclude="@Recently-Snapshot" --exclude="@Recycle" openbmclapi@lineapp.ltd::BMCLAPI-CACHE cache（密码是openbmclapi123）`

--- a/README.md
+++ b/README.md
@@ -118,3 +118,4 @@ openbmclapi 会自行同步需要的文件, 但是初次同步可能会速度过
 - `rsync -rzvP openbmclapi@home.933.moe::openbmclapi cache`
 - `rsync -avP openbmclapi@storage.yserver.ink::bmcl cache`
 - `rsync -azvrhP openbmclapi@openbmclapi.home.mxd.moe::volume cache`
+- `rsync -avP --delete --exclude="@Recently-Snapshot" --exclude="@Recycle" openbmclapi@lineapp.ltd::BMCLAPI-CACHE /pathtoyourcache/（密码是openbmclapi123）`


### PR DESCRIPTION
增加了来自TeamLINE的100M出口服务器，此服务器适合将OpenBMCLAPI搭建在Synology和QNAP品牌NAS的用户，以及TrueNAS Scale固件的用户

此服务器使用rsync 3.0.7，用来解决某些用户无法正常从rsync 3.2.7的服务器拉取文件的问题。