### PR TITLE
fix: 修复 URL 关键词添加错误

### DIFF
--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -81,7 +81,7 @@ export class Cluster {
     this._port = config.port
     this.publicPort = config.clusterPublicPort ?? config.port
     this.ua = `openbmclapi-cluster/${version}`
-    whiteListDomain.push(this.prefixUrl)
+    whiteListDomain.push(new URL(this.prefixUrl).hostname)
     this.got = got.extend({
       prefixUrl: this.prefixUrl,
       headers: {


### PR DESCRIPTION
总结就是直接把 prefixUrl 加进去了，没去掉 `https://` 之类的